### PR TITLE
Temporarily fix Twitch4J Oauth timeout

### DIFF
--- a/bot/resources/logback.xml
+++ b/bot/resources/logback.xml
@@ -14,9 +14,8 @@
     </appender>
 
     <logger name="logback" level="INFO"/>
-    <logger name="talium.inputs" level="WARN"/>
-    <logger name="talium.system" level="INFO"/>
-    <logger name="talium.coinsWatchtime" level="WARN"/>
+    <logger name="talium.twitch4J" level="INFO"/>
+    <logger name="talium.coinsWatchtime" level="INFO"/>
     <logger name="talium.ASCIIProgressbar" level="INFO"/>
 
     <logger name="talium.TwitchBot" level="INFO" additivity="false">


### PR DESCRIPTION
closes #70 (although further work is needed)

After some experiments, I figured out that this error occurs when the application is running while the access token runs out. Twitch4J then fails to get a new accessToken, although it is still possible, because the bot will work fine again, if you restart the application. This occurs somewhere between 3 and 6 Hours after application start, depending on when the accessToken was created. 

The logs mentioned something about not finding the twitch client ID. I experimented with different options to give the client ID to the twitch client, but nothing changed. 
Particularly interesting was the CredentialManager with A IStorageBackend and a AuthenticationController, because it _sounds_ exactly what we would need. But both are not really used by the CredentialManager, and the credential manager is discarded at the end of the TwitchClientBuilder. Only the TwitchIdentityProvider is extracted from it. The IdentityProvider does contain the twitchClientId, but the credential refresh fails for some reason anyway. 

The only solution that could be found in a short timeframe was periodically restarting the entire twitch module, because a full restart of the twitch bot always worked. 
Because the twitch access tokens seem to have a lifetime of 6 hours (measured from the token creation, not app startup), and the token can only be refreshed a few hours before its lifetime ends, a restart cycle of every 2 Hours was chosen. 


The entire solution is suboptimal, since this means that the bot will roughly be offline for at least twice per stream, for ca. 5 seconds each. This is entirely preventable. 
A better solution would be to ask the twitch4J maintainers how the automatic token refreshing is supposed to be used, and what it requires. But this may require a minimum example to make it reproducible. 